### PR TITLE
Fix the application form bugs

### DIFF
--- a/css/application.css
+++ b/css/application.css
@@ -75,10 +75,29 @@
   display: none;
 }
 
-@media (min-width: 1027px) {
+@media only screen and (min-width: 320px) and (max-width: 450px) {
+  .app-form__select-block::after {
+    content: url(../assets/svg/arrow-down.svg);
+    zoom: 80%;
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    pointer-events: none;
+  }
+}
+
+@media only screen and (min-width: 1200px) and (max-width: 1350px) {
+  .app-main {
+    padding: 100px 204px 168px;
+  }
+}
+
+@media (min-width: 1350px) {
+  .app-main {
+    padding: 100px 304px 268px;
+  }
   .app-section {
-    margin: 194px 200px;
-    max-width: 60%;
+    max-width: 1120px;
   }
 
   .app-form {

--- a/css/menu.css
+++ b/css/menu.css
@@ -102,6 +102,12 @@
 
 /* CALL ICON */
 
+.home-book-table-section__call-icon {
+  position: absolute;
+  z-index: 0;
+  right: 0;
+}
+
 .menu-page-content .home-book-table-section__call-icon--b202 {
   bottom: 618px;
 }

--- a/pages/application.html
+++ b/pages/application.html
@@ -65,7 +65,7 @@
         </ul>
       </nav>
     </header>
-    <main id="app-main">
+    <main id="app-main" class="app-main">
       <section id="app-section" class="app-section">
         <h1 class="fs-40 fw-700">Job Application</h1>
         <form method="POST" action="" class="app-form">


### PR DESCRIPTION
- The style for the call icon on the menu page is moved to the menu.css file since the styles for the call icon on the home page were changed to make the icon responsive (home page only);
- I set the max-width for the application form so that it doesn't become too stretched on the big screens;
- I set paddings for the main tag so that the application form is aligned in center when the screen's width is >1200px
- I added the "zoom" property for the "Job Role" icon dropdown to make it smaller on the smaller screens (320px - 450px)